### PR TITLE
feat: upgrade to v3

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -57,7 +57,7 @@ func uriCanonicalization(path string) string {
 }
 
 func queryStringCanonicalization(query url.Values) string {
-	queryPatternArray := []string{}
+	var queryPatternArray []string
 	for k, values := range query {
 		if strings.ToLower(k) == "authorization" {
 			continue
@@ -76,8 +76,8 @@ func queryStringCanonicalization(query url.Values) string {
 
 func headersCanonicalization(headers http.Header) (string, string) {
 	headersToSign := map[string]bool{"host": true, "content-md5": true, "content-length": true, "content-type": true}
-	canonicalHeaders := []string{}
-	signedHeaders := []string{}
+	var canonicalHeaders []string
+	var signedHeaders []string
 	for k, values := range headers {
 		k = strings.ToLower(k)
 		if headersToSign[k] || strings.HasPrefix(k, "x-bce-") {

--- a/baidusms.go
+++ b/baidusms.go
@@ -37,13 +37,17 @@ type ErrSendFail struct {
 }
 
 func (e *ErrSendFail) Error() string {
-	return fmt.Sprintf("Baidu SMS API error, httpcode: %d, code: %s, message: %s, requestID: %s",
-		e.HTTPCode, e.APICode, e.Message, e.RequestID)
+	return fmt.Sprintf(
+		"Baidu SMS API error, httpcode: %d, code: %s, message: %s, requestID: %s",
+		e.HTTPCode, e.APICode, e.Message, e.RequestID,
+	)
 }
 
-var (
+const (
 	// Version of baidusms
-	Version = "2.0.3"
+	Version = "3.0.0"
+	gzHost  = "smsv3.gz.baidubce.com"
+	bjHost  = "smsv3.bj.baidubce.com"
 )
 
 func (bd BaiduSMS) sendRequest(method string, path string, body string) (*SuccessResponse, error) {
@@ -51,9 +55,9 @@ func (bd BaiduSMS) sendRequest(method string, path string, body string) (*Succes
 	auth := auth{bd.AccessKey, bd.SecretKey}
 	var host string
 	if strings.ToLower(bd.Region) == "gz" {
-		host = "sms.gz.baidubce.com"
+		host = gzHost
 	} else {
-		host = "sms.bj.baidubce.com"
+		host = bjHost
 	}
 	targetURL := fmt.Sprintf("https://%s%s", host, path)
 	req, err := http.NewRequest(method, targetURL, strings.NewReader(body))
@@ -103,16 +107,22 @@ func (bd BaiduSMS) sendRequest(method string, path string, body string) (*Succes
 }
 
 type requestBody struct {
-	InvokeID     string            `json:"invokeId"`
+	SignatureID  string            `json:"signatureId"`
 	PhoneNumber  string            `json:"phoneNumber"`
 	TemplateCode string            `json:"templateCode"`
 	ContentVar   map[string]string `json:"contentVar"`
 }
 
 // SendSMSCode will call HTTP request to Baidu API to send a sms
-func (bd BaiduSMS) SendSMSCode(invokeID string, mobilePhoneNumber string, templateCode string, contentVar map[string]string) (*SuccessResponse, error) {
-	path := "/bce/v2/message"
-	body := requestBody{invokeID, mobilePhoneNumber, templateCode, contentVar}
+// phoneNumber should be array of E.164 phoneNumber
+func (bd BaiduSMS) SendSMSCode(
+	phoneNumber []string,
+	template string,
+	signatureID string,
+	contentVar map[string]string,
+) (*SuccessResponse, error) {
+	path := "/api/v3/sendSms"
+	body := requestBody{signatureID, strings.Join(phoneNumber, ","), template, contentVar}
 	bodyStr, err := json.Marshal(body)
 	if err != nil {
 		return nil, err

--- a/baidusms.go
+++ b/baidusms.go
@@ -13,6 +13,14 @@ import (
 	"time"
 )
 
+type Region = string
+
+const (
+	_        Region = ""
+	RegionBJ        = "bj"
+	RegionGZ        = "gz"
+)
+
 // BaiduSMS is config of sms service. AccessKey, SecretKey, Region should be provided
 // Region is one of "bj" and "gz"
 type BaiduSMS struct {

--- a/baidusms.go
+++ b/baidusms.go
@@ -107,22 +107,22 @@ func (bd BaiduSMS) sendRequest(method string, path string, body string) (*Succes
 }
 
 type requestBody struct {
-	SignatureID  string            `json:"signatureId"`
-	PhoneNumber  string            `json:"phoneNumber"`
-	TemplateCode string            `json:"templateCode"`
-	ContentVar   map[string]string `json:"contentVar"`
+	SignatureID string            `json:"signatureId"`
+	Mobile      string            `json:"mobile"`
+	Template    string            `json:"template"`
+	ContentVar  map[string]string `json:"contentVar"`
 }
 
 // SendSMSCode will call HTTP request to Baidu API to send a sms
-// phoneNumber should be array of E.164 phoneNumber
+// mobile should be array (length limited in 1-200) of E.164 phoneNumber
 func (bd BaiduSMS) SendSMSCode(
-	phoneNumber []string,
+	mobile []string,
 	template string,
 	signatureID string,
 	contentVar map[string]string,
 ) (*SuccessResponse, error) {
 	path := "/api/v3/sendSms"
-	body := requestBody{signatureID, strings.Join(phoneNumber, ","), template, contentVar}
+	body := requestBody{signatureID, strings.Join(mobile, ","), template, contentVar}
 	bodyStr, err := json.Marshal(body)
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/iftechio/baidusms/v2
+module github.com/iftechio/baidusms/v3
 
 go 1.12


### PR DESCRIPTION
> 本次升级截止日期：2020.8.20 24点，届时，将停止V2.0版本接口服务。

百度文档：https://cloud.baidu.com/doc/SMS/s/Yjwvxrwzb

BreakChanges：
1. InvokeID 变为 SignatureID，需要在百度短信后台获取
2. 手机号支持传入数组批量发送